### PR TITLE
fix: derive STATIC_DIR from __file__ and test local checkout in smoke test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -325,6 +325,12 @@ jobs:
           SKIP_SYSTEMD: "1"
         run: sudo -E bash install/install.sh
 
+      - name: Overwrite release with current checkout
+        run: |
+          sudo rsync -a --exclude='.venv' --exclude='__pycache__' \
+            ./ /opt/cineplete/
+          sudo chown -R cineplete:cineplete /opt/cineplete
+
       - name: Start app manually
         run: |
           sudo -u cineplete bash -c '

--- a/app/web.py
+++ b/app/web.py
@@ -5,6 +5,7 @@ Registers middleware, lifespan, and mounts all feature routers.
 Business logic lives in app/routers/*.
 """
 import os
+from pathlib import Path
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -18,7 +19,8 @@ from app import scheduler
 
 from app.routers import auth, config, scan, overrides, letterboxd, integrations, cache
 
-STATIC_DIR = os.getenv("STATIC_DIR", "/app/static")
+_BASE_DIR  = Path(__file__).resolve().parent.parent
+STATIC_DIR = os.getenv("STATIC_DIR", str(_BASE_DIR / "static"))
 
 # ---------------------------------------------------------------------------
 # Lifespan (scheduler start/stop)


### PR DESCRIPTION
## Summary
- `app/web.py`: `STATIC_DIR` now derives from `Path(__file__).resolve().parent.parent / "static"` so it resolves correctly under both `/opt/cineplete/` (bare-metal/LXC) and `/app/` (Docker) without needing `STATIC_DIR` set explicitly
- CI smoke test: `rsync` the local checkout over `/opt/cineplete` after `install.sh` runs, so the test validates the actual commit rather than the last published release artifact

## Test plan
- [ ] Smoke test passes in CI
- [ ] Docker build unaffected (STATIC_DIR env var still respected if set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)