### PR TITLE
fix: pre-fill Plex library name with "Movies" to prevent empty-field trap

### DIFF
--- a/static/js/config.js
+++ b/static/js/config.js
@@ -208,7 +208,7 @@ function addLibEntry(type) {
     url: "",
     token: "",
     api_key: "",
-    library_name: type === "jellyfin" ? "Movies" : "",
+    library_name: "Movies",
     page_size: 500,
     short_movie_limit: 60,
   }
@@ -356,7 +356,7 @@ function renderConfig(){
         <div id="lib-list">
           ${((CONFIG.LIBRARIES||[]).length
             ? CONFIG.LIBRARIES
-            : [{type:"plex",enabled:true,label:"",url:"",token:"",library_name:"",page_size:500,short_movie_limit:60}]
+            : [{type:"plex",enabled:true,label:"",url:"",token:"",library_name:"Movies",page_size:500,short_movie_limit:60}]
           ).map((lib, i) => _libEntryHtml(lib, i)).join("")}
         </div>
         <div style="display:flex;gap:.5rem;margin-top:.5rem">


### PR DESCRIPTION
## Problem

New Plex library entries had \`library_name: \"\"\` with a grey placeholder text of \`Movies\`. Users see the placeholder and assume the field is already filled in — they save without touching it, which stores \`library_name: \"\"\` in config.

\`is_configured()\` requires a non-empty \`library_name\`, so even with Plex URL + token + TMDB key all filled correctly, the app returns \`configured: false\` and blocks scanning with \"Complete setup first.\"

## Fix

Default new Plex entries (both from the initial blank entry on fresh install and from the \`+ Add Plex\` button) to \`library_name: \"Movies\"\` — matching the placeholder, which is the most common Plex library name.

Users who have a differently-named library will see \`Movies\` pre-filled and can change it; they won't be silently blocked.

## Related

Pairs with #31 which improves the error message to say exactly which field is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)