### PR TITLE
fix: surface actual error in Plex connection test instead of generic message

### DIFF
--- a/app/routers/config.py
+++ b/app/routers/config.py
@@ -105,18 +105,27 @@ def library_test(payload: dict = Body(...)):
                 return {"ok": False, "error": "URL and token are required"}
             if urlparse(url).scheme not in ("http", "https"):
                 return {"ok": False, "error": "URL must start with http:// or https://"}
+            import requests as _req
             lib_cfg = {"url": url, "token": token, "library_name": lib,
                        "page_size": 500, "short_movie_limit": 60}
-            xml  = plex_get("/library/sections", lib_cfg)
+            try:
+                xml  = plex_get("/library/sections", lib_cfg)
+            except _req.exceptions.ConnectionError as ce:
+                return {"ok": False, "error": f"Cannot reach Plex at {url} — {ce}"}
+            except _req.exceptions.HTTPError as he:
+                code = he.response.status_code if he.response is not None else "?"
+                if code == 401:
+                    return {"ok": False, "error": "Invalid Plex token (401 Unauthorized)"}
+                return {"ok": False, "error": f"Plex returned HTTP {code}"}
             root = _ET.fromstring(xml)
             libs = [d.attrib.get("title","") for d in root.findall("Directory")
                     if d.attrib.get("type") == "movie"]
             if lib and lib not in libs:
-                return {"ok": False, "error": f"Library '{lib}' not found. Available: {', '.join(libs)}"}
+                return {"ok": False, "error": f"Library '{lib}' not found. Available: {', '.join(libs) or 'none'}"}
             return {"ok": True, "libraries": libs}
     except Exception as e:
-        log.debug(f"Library test failed: {e}")
-        return {"ok": False, "error": "Could not connect — check URL and credentials"}
+        log.warning(f"Library test failed: {e}")
+        return {"ok": False, "error": str(e) or "Could not connect — check URL and credentials"}
 
 
 # --------------------------------------------------


### PR DESCRIPTION
## Problem

The Plex library test caught all exceptions and returned the same generic
\`"Could not connect — check URL and credentials"\` message regardless of
the real cause. Users with Docker networking issues (e.g. Synology where
the container can't reach the host LAN IP) get no useful diagnostic info.

## Changes

- Plex test now catches \`ConnectionError\` and \`HTTPError\` separately and
  returns the actual error string (e.g. \`"Cannot reach Plex at http://... — [Errno 111] Connection refused"\`)
- 401 returns \`"Invalid Plex token (401 Unauthorized)"\` explicitly
- Outer catch now returns \`str(e)\` instead of the hardcoded generic message
- Exception is logged at \`WARNING\` instead of \`DEBUG\` so it shows in logs

## Why

On Synology Docker, the container often can't reach the host via LAN IP
(\`192.168.x.x\`). The user needs to see the actual error to know whether
to try \`host.docker.internal\`, the Docker bridge IP (\`172.17.0.1\`),
or a container name. The generic message gave them nothing to go on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)