### PR TITLE
fix: add host.docker.internal for Synology/NAS Docker networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,6 @@ services:
       timeout: 10s
       retries: 5
       start_period: 20s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped


### PR DESCRIPTION
## Problem

On Synology (and other NAS/homelab Docker hosts), the container cannot
reach services on the host machine using the LAN IP (`192.168.x.x`).
Users running both CinePlete and Plex on the same Synology get
"Could not connect" when testing the Plex connection.

## Fix

Add `extra_hosts: host.docker.internal:host-gateway` to `docker-compose.yml`.

`host-gateway` is a special Docker value that resolves to the host's
internal Docker bridge IP at runtime. This works on Synology DSM 7+,
Unraid, and any standard Linux Docker host.

## User instructions

After pulling the new compose file and recreating the container, use:
\`\`\`
http://host.docker.internal:32400
\`\`\`
instead of the LAN IP when Plex/Jellyfin runs on the same machine as CinePlete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)