### PR TITLE
fix: silence urllib3 DEBUG logs (TMDB API key was leaking in logs)

### DIFF
--- a/app/logger.py
+++ b/app/logger.py
@@ -69,6 +69,7 @@ def _setup():
     # Silence noisy third-party loggers
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 def get_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
## Problem

urllib3 logs full request URLs at DEBUG level, which includes the TMDB API key as a query parameter:
\`\`\`
[DEBUG] urllib3.connectionpool — https://api.themoviedb.org:443 "GET /3/movie/42212?api_key=<SECRET>"
\`\`\`
This exposes the API key in the log file and any Docker log viewer. Users were unknowingly sharing their API keys when posting logs.

## Fix

One line — silence `urllib3` to `WARNING`, the same way `httpx` and `uvicorn.access` are already silenced.

## Note

The `TMDB._cache_key()` method already strips the API key from cache keys, so this was partially addressed in the app layer but not at the HTTP layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)