### PR TITLE
fix: all Critical and High severity bugs (C1-C4, H1-H6, M3)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -49,11 +49,39 @@ def is_local_address(ip_str: str) -> bool:
 
 
 def get_client_ip(request) -> str:
-    """Extract real client IP, respecting X-Forwarded-For for reverse proxies."""
-    xff = request.headers.get("X-Forwarded-For", "")
-    if xff:
-        return xff.split(",")[0].strip()
-    return request.client.host if request.client else "127.0.0.1"
+    """
+    Extract the real client IP.
+
+    X-Forwarded-For is only trusted when the direct connection comes from an
+    IP listed in AUTH.TRUSTED_PROXIES (comma-separated IPs/CIDRs). Trusting
+    XFF blindly allows spoofing by setting the header to 127.0.0.1, which
+    would bypass DisabledForLocalAddresses auth.
+    """
+    from app.config import load_config
+    client_host = request.client.host if request.client else "127.0.0.1"
+
+    trusted_raw = load_config().get("AUTH", {}).get("TRUSTED_PROXIES", "").strip()
+    if trusted_raw:
+        trusted_nets = []
+        for entry in trusted_raw.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            try:
+                trusted_nets.append(ipaddress.ip_network(entry, strict=False))
+            except ValueError:
+                pass
+
+        try:
+            client_ip = ipaddress.ip_address(client_host)
+            if any(client_ip in net for net in trusted_nets):
+                xff = request.headers.get("X-Forwarded-For", "")
+                if xff:
+                    return xff.split(",")[0].strip()
+        except ValueError:
+            pass
+
+    return client_host
 
 
 # ---------------------------------------------------------------------------

--- a/app/config.py
+++ b/app/config.py
@@ -108,6 +108,9 @@ DEFAULT_CONFIG = {
         "AUTH_PASSWORD_HASH": "",
         "AUTH_PASSWORD_SALT": "",
         "AUTH_SECRET_KEY": "",   # auto-generated on first save
+        # Comma-separated IPs/CIDRs whose X-Forwarded-For header is trusted.
+        # Only set this if CinePlete sits behind a known reverse proxy.
+        "TRUSTED_PROXIES": "",
     },
 }
 

--- a/app/routers/integrations.py
+++ b/app/routers/integrations.py
@@ -188,8 +188,10 @@ def overseerr_add(payload: dict = Body(...)):
     tmdb_id = _parse_tmdb_id(payload.get("tmdb"))
     if tmdb_id is None:
         return {"ok": False, "error": "Invalid TMDB ID"}
-    headers = {"X-Api-Key": cfg["OVERSEERR_API_KEY"],
-               "Content-Type": "application/json"}
+    api_key = cfg.get("OVERSEERR_API_KEY", "").strip()
+    if not api_key:
+        return {"ok": False, "error": "Overseerr API key not configured"}
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
     try:
         r = requests.post(
             f"{cfg['OVERSEERR_URL'].rstrip('/')}/api/v1/request",
@@ -215,8 +217,10 @@ def jellyseerr_add(payload: dict = Body(...)):
     tmdb_id = _parse_tmdb_id(payload.get("tmdb"))
     if tmdb_id is None:
         return {"ok": False, "error": "Invalid TMDB ID"}
-    headers = {"X-Api-Key": cfg["JELLYSEERR_API_KEY"],
-               "Content-Type": "application/json"}
+    api_key = cfg.get("JELLYSEERR_API_KEY", "").strip()
+    if not api_key:
+        return {"ok": False, "error": "Jellyseerr API key not configured"}
+    headers = {"X-Api-Key": api_key, "Content-Type": "application/json"}
     try:
         r = requests.post(
             f"{cfg['JELLYSEERR_URL'].rstrip('/')}/api/v1/request",

--- a/app/routers/letterboxd.py
+++ b/app/routers/letterboxd.py
@@ -194,11 +194,16 @@ def _fetch_letterboxd_rss(url: str, _depth: int = 0, flaresolverr: str = "") -> 
         elif item_link:
             list_links.append((item_link, item_desc))
 
+    _MAX_MOVIES_PER_FEED = 500   # cap to prevent thousands of TMDB calls per URL
+
     if not movies and list_links and _depth == 0:
         log.debug(
             f"Letterboxd: lists feed at {rss_url} — expanding {len(list_links)} lists"
         )
         for list_url, desc_html in list_links[:10]:
+            if len(movies) >= _MAX_MOVIES_PER_FEED:
+                log.debug(f"Letterboxd: reached {_MAX_MOVIES_PER_FEED}-movie cap, stopping expansion")
+                break
             child_movies = _fetch_letterboxd_rss(list_url, _depth=1, flaresolverr=flaresolverr)
             if child_movies:
                 movies.extend(child_movies)
@@ -210,7 +215,7 @@ def _fetch_letterboxd_rss(url: str, _depth: int = 0, flaresolverr: str = "") -> 
                 )
                 movies.extend(fallback)
 
-    return movies
+    return movies[:_MAX_MOVIES_PER_FEED]
 
 
 def _validate_letterboxd_url(url: str):

--- a/app/routers/scan.py
+++ b/app/routers/scan.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Query
 from fastapi.responses import PlainTextResponse
 
 from app.config import load_config, is_configured
-from app.scanner import build_async, scan_state
+from app.scanner import build_async, scan_state, _scan_lock
 from app.routers._shared import log, read_results, LOG_FILE
 
 router = APIRouter()
@@ -69,16 +69,17 @@ def api_scan_status():
     Returns current scan progress. Poll this while scan_state['running'] is True.
     When running is False and error is None, fetch /api/results for fresh data.
     """
-    return {
-        "running":        scan_state["running"],
-        "step":           scan_state["step"],
-        "step_index":     scan_state["step_index"],
-        "step_total":     scan_state["step_total"],
-        "detail":         scan_state["detail"],
-        "error":          scan_state["error"],
-        "last_completed": scan_state["last_completed"],
-        "last_duration":  scan_state["last_duration"],
-    }
+    with _scan_lock:
+        return {
+            "running":        scan_state["running"],
+            "step":           scan_state["step"],
+            "step_index":     scan_state["step_index"],
+            "step_total":     scan_state["step_total"],
+            "detail":         scan_state["detail"],
+            "error":          scan_state["error"],
+            "last_completed": scan_state["last_completed"],
+            "last_duration":  scan_state["last_duration"],
+        }
 
 
 # --------------------------------------------------

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -71,11 +71,13 @@ def save_snapshot(plex_ids: dict):
     """Persist current library TMDB IDs for progressive scan comparison."""
     try:
         os.makedirs(DATA_DIR, exist_ok=True)
-        with open(SNAPSHOT_FILE, "w", encoding="utf-8") as f:
+        tmp = SNAPSHOT_FILE + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump({
                 "plex_ids": list(plex_ids.keys()),
                 "saved_at": datetime.utcnow().isoformat() + "Z",
             }, f)
+        os.replace(tmp, SNAPSHOT_FILE)
     except OSError as e:
         log.warning(f"Could not save scan snapshot: {e}")
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -206,7 +206,7 @@ def _poll_radarr_grabs() -> None:
     flood of notifications for past grabs on first start).
     """
     import time
-    from app.telegram import send_radarr_grab
+    from app.telegram import send_radarr_grab, send_radarr_grab_batch
 
     cfg    = load_config()
     radarr = cfg.get("RADARR", {})
@@ -250,14 +250,22 @@ def _poll_radarr_grabs() -> None:
     first_run  = not os.path.exists(GRAB_SEEN_FILE)
 
     if first_run:
-        # Seed without notifying — avoids a blast on first start
+        # Seed only recent events (last 7 days) to avoid loading unbounded history
+        from datetime import datetime, timezone, timedelta
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
         for event in records:
-            seen_ids.add(event.get("id"))
+            grabbed_at = event.get("date", "")
+            try:
+                dt = datetime.fromisoformat(grabbed_at.replace("Z", "+00:00"))
+                if dt >= cutoff:
+                    seen_ids.add(event.get("id"))
+            except Exception:
+                seen_ids.add(event.get("id"))
         _save_seen_ids(seen_ids)
-        log.info(f"Radarr grab poller: first run, seeded {len(seen_ids)} event IDs")
+        log.info(f"Radarr grab poller: first run, seeded {len(seen_ids)} recent event IDs")
         return
 
-    notified = 0
+    grabbed_movies: list[tuple[str, str | None]] = []
     for event in records:
         event_id = event.get("id")
         if not event_id or event_id in seen_ids:
@@ -269,13 +277,16 @@ def _poll_radarr_grabs() -> None:
         if tmdb_id and tmdb_id in wishlist:
             title = event.get("movie", {}).get("title", "Unknown")
             year  = str(event.get("movie", {}).get("year", "")) or None
-            send_radarr_grab(title, year)
-            notified += 1
-            time.sleep(0.05)   # Telegram rate-limit safeguard
+            grabbed_movies.append((title, year))
 
     _save_seen_ids(seen_ids)
-    if notified:
-        log.info(f"Radarr grab poller: {notified} wishlist grab(s) notified")
+
+    if grabbed_movies:
+        if len(grabbed_movies) == 1:
+            send_radarr_grab(*grabbed_movies[0])
+        else:
+            send_radarr_grab_batch(grabbed_movies)
+        log.info(f"Radarr grab poller: {len(grabbed_movies)} wishlist grab(s) notified")
 
 
 def _scheduled_scan():
@@ -386,7 +397,9 @@ def stop():
     """Stop the scheduler cleanly."""
     global _scheduler
     if _scheduler and _scheduler.running:
-        _scheduler.shutdown(wait=False)
+        # wait=True lets any in-flight poll/trigger job finish before shutting down
+        # (jobs are short — they only launch threads, not block until scan completes)
+        _scheduler.shutdown(wait=True)
         log.info("Library polling stopped")
 
 

--- a/app/telegram.py
+++ b/app/telegram.py
@@ -129,7 +129,7 @@ def send_scan_summary(results: dict, duration_s: int | None = None):
 
 def send_radarr_grab(title: str, year: str | None = None) -> None:
     """
-    Send a Telegram notification when Radarr grabs a wishlist movie.
+    Send a Telegram notification when Radarr grabs a single wishlist movie.
     Does NOT enforce TELEGRAM_MIN_INTERVAL — each grab is a discrete event.
     """
     cfg     = load_config()
@@ -145,3 +145,26 @@ def send_radarr_grab(title: str, year: str | None = None) -> None:
     if _send(token, chat_id, text):
         log.info(f"Telegram grab notification sent: {title}")
         time.sleep(1.1)   # respect Telegram rate limit (1 msg/sec for private chats)
+
+
+def send_radarr_grab_batch(movies: list[tuple[str, str | None]]) -> None:
+    """
+    Send a single batched Telegram notification for multiple Radarr grabs.
+    Used when more than one wishlist movie is grabbed at once to avoid
+    hitting Telegram's rate limit with individual messages.
+    """
+    cfg     = load_config()
+    tg      = cfg.get("TELEGRAM", {})
+    if not tg.get("TELEGRAM_ENABLED"):
+        return
+    token   = tg.get("TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = tg.get("TELEGRAM_CHAT_ID",   "").strip()
+    if not token or not chat_id:
+        return
+    lines = []
+    for title, year in movies:
+        year_str = f" ({year})" if year else ""
+        lines.append(f"• {title}{year_str}")
+    text = f"⬇️ *Radarr grabbed {len(movies)} wishlist movies:*\n" + "\n".join(lines)
+    if _send(token, chat_id, text):
+        log.info(f"Telegram batch grab notification sent: {len(movies)} movies")

--- a/app/tmdb.py
+++ b/app/tmdb.py
@@ -16,6 +16,7 @@ CACHE_FILE = f"{DATA_DIR}/tmdb_cache.json"
 FLUSH_EVERY = 50
 
 _RETRY_DELAYS = (2, 4, 8)   # seconds between network-error retries
+MAX_CACHE_ENTRIES = 10_000  # LRU eviction threshold
 
 
 def ensure_data_dir():
@@ -110,7 +111,7 @@ class TMDB:
             if r.status_code >= 500:
                 self._error_count += 1
                 log.warning(f"TMDB server error {r.status_code} (attempt {attempt}) — {cache_key}")
-                if attempt > 1:
+                if attempt > len(_RETRY_DELAYS):
                     return {}
                 time.sleep(5)
                 continue
@@ -140,7 +141,8 @@ class TMDB:
         time.sleep(self.delay)
         data = self._request(url)
 
-        # Write back under lock
+        # Write back under lock — take a snapshot for flushing outside the lock
+        cache_snapshot = None
         with self._lock:
             # Double-check: another thread may have fetched same key while we waited
             if cache_key in self.cache:
@@ -150,9 +152,17 @@ class TMDB:
                 self.cache[cache_key] = data
                 self._calls_since_flush += 1
 
+                # Evict oldest entries (insertion-order LRU) if over limit
+                while len(self.cache) > MAX_CACHE_ENTRIES:
+                    self.cache.pop(next(iter(self.cache)))
+
                 if self._calls_since_flush >= FLUSH_EVERY:
-                    save_cache(self.cache)
-                    self._calls_since_flush = 0
+                    self._calls_since_flush = 0          # reset inside lock
+                    cache_snapshot = dict(self.cache)    # snapshot inside lock
+
+        # File I/O outside the lock so other threads aren't blocked
+        if cache_snapshot is not None:
+            save_cache(cache_snapshot)
 
         return data
 


### PR DESCRIPTION
## Summary

Fixes all 4 Critical and all 6 High severity bugs from the bug report, plus M3 (TMDB retry logic) as a bonus.

---

## Critical

| ID | Fix |
|----|-----|
| C1 | TMDB cache flush race — reset counter inside lock, write file **outside** lock so threads don't block each other |
| C2 | Unbounded cache memory — LRU eviction at 10k entries using dict insertion order |
| C3 | X-Forwarded-For auth bypass — XFF only trusted when direct connection IP is in new `TRUSTED_PROXIES` config (default empty = XFF ignored) |
| C4 | KeyError on missing Overseerr/Jellyseerr API key — `.get()` with early clean error return |

## High

| ID | Fix |
|----|-----|
| H1 | `scan_state` torn reads — `api_scan_status` now reads under `_scan_lock` |
| H2 | Telegram bulk rate limit — collect all grabs, send one batched message when >1 movie grabbed |
| H3 | Scheduler restart killing jobs — `shutdown(wait=True)` so in-flight poll finishes first |
| H4 | Radarr first-run seeding all history — limit seed to last 7 days |
| H5 | Letterboxd feed explosion — 500-movie cap per feed to prevent thousands of TMDB calls |
| H6 | Non-atomic snapshot write — `tmp + os.replace()` pattern matching `write_results()` |

## Bonus: M3
TMDB 5xx retry now uses the same 3-attempt `_RETRY_DELAYS` logic as network errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)