### PR TITLE
fix: PUID/PGID support for Synology/NAS (issue #38)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,19 @@ COPY app /app/app
 COPY static /app/static
 COPY config /app/config
 
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+COPY entrypoint.sh /entrypoint.sh
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 RUN useradd -m -u 1000 cineplete && \
     mkdir -p /data /config && \
-    chown -R cineplete:cineplete /app /data /config
-USER cineplete
+    chown -R cineplete:cineplete /app /data /config && \
+    chmod +x /entrypoint.sh
 
 EXPOSE 8787
 
-CMD ["uvicorn", "app.web:app", "--host", "0.0.0.0", "--port", "8787"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/app/routers/config.py
+++ b/app/routers/config.py
@@ -66,7 +66,11 @@ def api_save_config(payload: dict = Body(...)):
     )
 
     payload["AUTH"] = auth_payload
-    cfg = save_config(payload)
+    try:
+        cfg = save_config(payload)
+    except OSError as e:
+        log.error(f"Cannot write config file: {e}")
+        return {"ok": False, "error": f"Cannot write to /config — check folder permissions and PUID/PGID ({e})"}
     scheduler.restart()
     return {"ok": True, "configured": is_configured(cfg)}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   cineplete:
     image: sdblepas/cineplete:latest
     container_name: cineplete
+    environment:
+      - PUID=1000   # set to your host user ID (id -u)
+      - PGID=1000   # set to your host group ID (id -g)
     ports:
       - "8787:8787"
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+echo "Starting CinePlete with UID=${PUID} GID=${PGID}"
+
+# Remap the cineplete group and user to match the host PGID/PUID
+groupmod -o -g "$PGID" cineplete
+usermod  -o -u "$PUID" cineplete
+
+# Fix ownership of writable directories
+chown -R cineplete:cineplete /data /config
+
+# Drop privileges and start the app
+exec gosu cineplete uvicorn app.web:app --host 0.0.0.0 --port 8787


### PR DESCRIPTION
## Problem

Fixes #38

The container hardcoded UID 1000 for the `cineplete` user. On Synology and other NAS hosts, `/config` and `/data` are owned by a different UID/GID, so the container failed to write config — resulting in a raw HTTP 500 with no useful message.

The `fix/configsave` branch's improved error handling made this visible: users now see `"Error saving config: HTTP 500: Internal Server Error"` instead of silent failure.

## Changes

### `entrypoint.sh` (new)
Reads `PUID`/`PGID` env vars at container startup, remaps the `cineplete` user to match, fixes ownership on `/data` and `/config`, then drops privileges with `gosu` before launching uvicorn. Same pattern as LinuxServer containers.

### `Dockerfile`
- Install `gosu`
- `COPY entrypoint.sh`
- Switch from `CMD` to `ENTRYPOINT`
- Remove hardcoded `USER cineplete` (entrypoint handles privilege drop)

### `docker-compose.yml`
Add `PUID`/`PGID` environment vars (default `1000`) so users know to set them.

### `app/routers/config.py`
Catch `OSError` in `api_save_config` and return a clear error:
> `"Cannot write to /config — check folder permissions and PUID/PGID"`

instead of a raw 500.

## User instructions

Set `PUID` and `PGID` in your compose file to match the owner of your `/config` and `/data` folders:
```bash
id -u   # → your PUID
id -g   # → your PGID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)