### PR TITLE
chore(deps): batch dependency updates Apr 26

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: fs
           scan-ref: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastapi==0.136.0
-uvicorn==0.44.0
+fastapi==0.136.1
+uvicorn==0.46.0
 requests==2.33.1
 pyyaml==6.0.2
 apscheduler==3.10.4


### PR DESCRIPTION
Consolidates three Dependabot PRs into a single CI run.

## Changes

| Dependency | From | To | Type |
|---|---|---|---|
| `fastapi` | 0.136.0 | 0.136.1 | patch — Pydantic v2 deprecation fixes |
| `uvicorn` | 0.44.0 | 0.46.0 | minor — wsproto ws_max_size, proxy port preservation |
| `aquasecurity/trivy-action` | 0.35.0 | 0.36.0 | Trivy v0.70.0, portable shebang fix |

Closes #62, #63, #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)